### PR TITLE
Updated docs

### DIFF
--- a/docs/totalcloud.md
+++ b/docs/totalcloud.md
@@ -120,7 +120,7 @@ print(dumps(get_aws_base_account(auth), indent=2))
 
 #### ```filter``` Search Tokens
 
->>**Head's Up!:** When using ```resource.type``` as the filter, you must use the API-expected name. See **```resourceType``` Values** table for expected names.
+>**Head's Up!:** When using ```resource.type``` as the filter, you must use the API-expected name. See **```resourceType``` Values** table for expected names.
 
 |Token| Description |
 |--|--|
@@ -159,7 +159,7 @@ get_control_metadata(auth, filter='resource.type:BUCKET')
 
 This function takes advantage of multithreading to pull down data faster. You can specify the number of threads with the ```thread_count``` argument, which defaults to 5.
 
->>**Head's Up!:** At maximum, this API endpoint returns 10,000 records. This is a hard limit imposed by Qualys. If you have more than 10K records under a single ```resourceType```, you will need to use the ```filter``` argument to narrow down the results and make repeated calls to get all the data. An easy way to do this is to use ```totalcloud.get_connectors()```, then use the connector's account ID (```subscriptionId``` for Azure) attribute in this API call's ```filter``` argument, storing the results in a ```BaseList```. For example: 
+>**Head's Up!:** At maximum, this API endpoint returns 10,000 records. This is a hard limit imposed by Qualys. If you have more than 10K records under a single ```resourceType```, you will need to use the ```filter``` argument to narrow down the results and make repeated calls to get all the data. An easy way to do this is to use ```totalcloud.get_connectors()```, then use the connector's account ID (```subscriptionId``` for Azure) attribute in this API call's ```filter``` argument, storing the results in a ```BaseList```. For example: 
 
 ```py
 from qualysdk import BaseList

--- a/docs/vmdr.md
+++ b/docs/vmdr.md
@@ -68,6 +68,7 @@ Some important kwargs this API accepts:
 |```ids```|```None/hostIDs```|Filter API output to a specific set of host IDs. Can be a comma-separated string: ```1357,2468,8901```, a range: ```12345-54321```, or a single host ID: ```12345```.|
 
 >**Heads Up!**: For a full breakdown of acceptable kwargs, see Qualys' documentation [here](https://cdn2.qualys.com/docs/qualys-api-vmpc-user-guide.pdf).
+
 ```py
 from qualysdk import BasicAuth
 from qualysdk.vmdr import get_hld

--- a/docs/was.md
+++ b/docs/was.md
@@ -22,7 +22,7 @@ You can use any of the endpoints currently supported:
 
 ```count_webapps``` returns the number of web apps in the subscription that match the given kwargs.
 
->>**Head's Up!** This method is useful for quickly getting a count of webapps that match a certain criteria. It does NOT return the webapps themselves, or any attributes of the webapps.
+>**Head's Up!** This method is useful for quickly getting a count of webapps that match a certain criteria. It does NOT return the webapps themselves, or any attributes of the webapps.
 
 |Parameter| Possible Values |Description| Required|
 |--|--|--|--|

--- a/qualysdk/base/call_schema.py
+++ b/qualysdk/base/call_schema.py
@@ -434,7 +434,8 @@ CALL_SCHEMA = frozendict(
                     "default_scanner",
                     "scanners_in_ag",
                     "scanners_in_network",  # set to 1 to use all scanners
-                    "target_from" "use_ip_nt_range_tags_include",  # must be tags
+                    "target_from",
+                    "use_ip_nt_range_tags_include",  # must be tags
                     "use_ip_nt_range_tags_exclude",
                     "use_ip_nt_range_tags",
                     "tag_include_selector",

--- a/qualysdk/base/call_schema.py
+++ b/qualysdk/base/call_schema.py
@@ -434,8 +434,7 @@ CALL_SCHEMA = frozendict(
                     "default_scanner",
                     "scanners_in_ag",
                     "scanners_in_network",  # set to 1 to use all scanners
-                    "target_from"  # must be tags
-                    "use_ip_nt_range_tags_include",
+                    "target_from" "use_ip_nt_range_tags_include",  # must be tags
                     "use_ip_nt_range_tags_exclude",
                     "use_ip_nt_range_tags",
                     "tag_include_selector",


### PR DESCRIPTION
Some of the:

>**Head’s Up!**s 

were incorrectly formatted with two >>s

Also fixed a code example not having a line of whitespace between it and a head’s up in VMDR docs.