### PR TITLE
Added retest fields for WASFinding. Breaking change to DBs (new columns)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualysdk"
-version = "0.2.8"
+version = "0.2.9"
 description = "SDK for interacting with Qualys APIs, across most modules the platform offers."
 authors = ["0x41424142 <jake@jakelindsay.uk>", "0x4A616B65 <jake.lindsay@thermofisher.com>"]
 maintainers = ["Jake Lindsay <jake@jakelindsay.uk>"]

--- a/qualysdk/sql/was.py
+++ b/qualysdk/sql/was.py
@@ -434,6 +434,26 @@ def upload_was_findings(
             TEXT(charset="utf8"), "mysql", "mariadb"
         ),
         "updatedDate": types.DateTime(),
+        "retestStatus": types.String().with_variant(
+            TEXT(charset="utf8"), "mysql", "mariadb"
+        ),
+        "retestedDate": types.DateTime(),
+        "retestedUser_id": types.Integer(),
+        "retestedUser_username": types.String().with_variant(
+            TEXT(charset="utf8"), "mysql", "mariadb"
+        ),
+        "retestedUser_firstName": types.String().with_variant(
+            TEXT(charset="utf8"), "mysql", "mariadb"
+        ),
+        "retestedUser_lastName": types.String().with_variant(
+            TEXT(charset="utf8"), "mysql", "mariadb"
+        ),
+        "retestFindingStatus": types.String().with_variant(
+            TEXT(charset="utf8"), "mysql", "mariadb"
+        ),
+        "retestReason": types.String().with_variant(
+            TEXT(charset="utf8"), "mysql", "mariadb"
+        ),
     }
 
     # Prepare the dataclass for insertion:
@@ -450,6 +470,7 @@ def upload_was_findings(
             "history",
             "wasc",
             "sslData",
+            "retest",
         ],
         inplace=True,
     )

--- a/qualysdk/was/data_classes/Finding.py
+++ b/qualysdk/was/data_classes/Finding.py
@@ -272,6 +272,17 @@ class WASFinding(BaseClass):
     sslData_certificateFingerprint: BaseList[str] = None
     sslData_flags: str = None
     updatedDate: datetime = None
+    retest: dict = None
+    # retest is parsed into below:
+    retestStatus: str = None
+    retestedDate: datetime = None
+    retestedUser_id: int = None
+    retestedUser_username: str = None
+    retestedUser_firstName: str = None
+    retestedUser_lastName: str = None
+    retestFindingStatus: str = None
+    retestReason: str = None
+    # end of retest
 
     def __post_init__(self):
         DT_FIELDS = [
@@ -292,6 +303,7 @@ class WASFinding(BaseClass):
             "webApp_id",
             "patch",
             "reactivateIn",
+            "retestedUser_id",
         ]
         BOOL_FIELDS = ["potential", "isIgnored"]
 
@@ -318,22 +330,6 @@ class WASFinding(BaseClass):
 
         if self.param:
             setattr(self, "param", unquote_plus(self.param))
-
-        for int_field in INT_FIELDS:
-            if getattr(self, int_field):
-                setattr(self, int_field, int(getattr(self, int_field)))
-
-        for bool_field in BOOL_FIELDS:
-            if getattr(self, bool_field):
-                setattr(self, bool_field, bool(getattr(self, bool_field)))
-
-        for dt_field in DT_FIELDS:
-            if getattr(self, dt_field):
-                setattr(
-                    self,
-                    dt_field,
-                    datetime.strptime(getattr(self, dt_field), "%Y-%m-%dT%H:%M:%SZ"),
-                )
 
         if self.cwe:
             setattr(self, "cwe_count", int(self.cwe.get("count")))
@@ -456,6 +452,36 @@ class WASFinding(BaseClass):
 
                 self.sslData_list = bl
             setattr(self, "sslData", None)
+
+        if self.retest:
+            setattr(self, "retestStatus", self.retest.get("retestStatus"))
+            date = self.retest.get("retestedDate")
+            if date:
+                setattr(self, "retestedDate", datetime.fromisoformat(date))
+            user = self.retest.get("retestedUser")
+            if user:
+                setattr(self, "retestedUser_id", user.get("id"))
+                setattr(self, "retestedUser_username", user.get("username"))
+                setattr(self, "retestedUser_firstName", user.get("firstName"))
+                setattr(self, "retestedUser_lastName", user.get("lastName"))
+            setattr(self, "retestFindingStatus", self.retest.get("findingStatus"))
+            setattr(self, "retestReason", self.retest.get("reason"))
+
+        for int_field in INT_FIELDS:
+            if getattr(self, int_field):
+                setattr(self, int_field, int(getattr(self, int_field)))
+
+        for bool_field in BOOL_FIELDS:
+            if getattr(self, bool_field):
+                setattr(self, bool_field, bool(getattr(self, bool_field)))
+
+        for dt_field in DT_FIELDS:
+            if getattr(self, dt_field):
+                setattr(
+                    self,
+                    dt_field,
+                    datetime.strptime(getattr(self, dt_field), "%Y-%m-%dT%H:%M:%SZ"),
+                )
 
     def __int__(self) -> int:
         return self.id

--- a/qualysdk/was/findings.py
+++ b/qualysdk/was/findings.py
@@ -325,7 +325,7 @@ def get_findings_verbose(
     Uses ```was.get_findings()``` and ```was.get_finding_details()``` to return a ```BaseList``` of ```WASFinding```s with
     all attributes populated.
 
-    This function is multi-threaded, placing all ```WASFinding```s found
+    This function is multi-threaded, placing all ```WASFinding``` objects found
     from ```was.get_findings()``` into a queue and then spawning threads to pull the details one
     by one.
 


### PR DESCRIPTION
Added retest fields for WASFinding dataclasses.

    retest: dict = None
    # retest is parsed into below:
    retestStatus: str = None
    retestedDate: datetime = None
    retestedUser_id: int = None
    retestedUser_username: str = None
    retestedUser_firstName: str = None
    retestedUser_lastName: str = None
    retestFindingStatus: str = None
    retestReason: str = None

SQL has also been updated to support these fields. any tables already created will need to add these columns.