### PR TITLE
Proxy_url optional parameter added into the auth classes

### DIFF
--- a/qualysdk/auth/basic.py
+++ b/qualysdk/auth/basic.py
@@ -22,7 +22,7 @@ class BasicAuth(BaseAuthentication):
     ```
     platform: str - the platform for the basic authentication. Defaults to "qg3", but can be "qg[1-4]"
     ```
-    Other attributes are inherited from BaseAuthentication - AKA username, password, token, and auth_type
+    Other attributes are inherited from BaseAuthentication - AKA username, password, proxy_url, token, and auth_type
     """
 
     platform: Literal["qg1", "qg2", "qg3", "qg4"] = field(default="qg3", init=True)
@@ -33,7 +33,6 @@ class BasicAuth(BaseAuthentication):
         """
         if self.platform not in ["qg1", "qg2", "qg3", "qg4"]:
             raise ValueError("Platform must be one of 'qg1', 'qg2', 'qg3', or 'qg4'.")
-
         super().__post_init__()
         self.validate_type()
         # self.auth_type = "basic"
@@ -53,6 +52,7 @@ class BasicAuth(BaseAuthentication):
         return {
             "username": self.username,
             "password": self.password,
+            "proxy_url": self.proxy_url,
             "token": self.token,
             "auth_type": self.auth_type,
             "platform": self.platform,
@@ -98,7 +98,7 @@ class BasicAuth(BaseAuthentication):
             url = "https://qualysapi.qualys.com/msp/about.php"
 
         """Requires basic auth. JWT is not supported for this endpoint."""
-        r = get(url, auth=(self.username, self.password))
+        r = get(url, auth=(self.username, self.password),proxies=self.proxy_url)
 
         if r.status_code != 200:
             raise AuthenticationError(f"Failed to authenticate. Requests reporting: {r.text}")

--- a/qualysdk/auth/token.py
+++ b/qualysdk/auth/token.py
@@ -15,7 +15,7 @@ from ..exceptions import AuthenticationError
 class TokenAuth(BasicAuth):
     """
     TokenAuth - handles API endpoints that require JWT authentication.
-    This class will take the username, password, and platform attributes from BasicAuth and use them to generate a JWT token via the Qualys JWT-generatio API.
+    This class will take the username, password,  proxy_url and platform attributes from BasicAuth and use them to generate a JWT token via the Qualys JWT-generatio API.
 
     Attributes:
     ```
@@ -55,7 +55,7 @@ class TokenAuth(BasicAuth):
 
         print(f"Generating token for {self.username} on {self.platform} platform.")
 
-        r = post(url, headers=headers, data=payload)
+        r = post(url, headers=headers, data=payload,proxies=self.proxy_url)
 
         if r.status_code != 201:
             raise AuthenticationError(f"Failed to generate token. Requests reporting: {r.text}")

--- a/qualysdk/base/call_api.py
+++ b/qualysdk/base/call_api.py
@@ -226,6 +226,7 @@ def call_api(
             data=payload if not use_json else None,
             json=jsonbody if use_json else None,
             auth=(auth_tuple if auth.auth_type == "basic" else None),
+            proxies=auth.proxy_url,
         )
 
         # check for errors not related to rate limiting:

--- a/qualysdk/base/call_api.py
+++ b/qualysdk/base/call_api.py
@@ -288,6 +288,7 @@ def call_api(
                     data=payload if not use_json else None,
                     json=jsonbody if use_json else None,
                     auth=(auth_tuple if auth.auth_type == "basic" else None),
+                    proxies=auth.proxy_url,
                 )
 
                 # Isolate the wait time from the header:

--- a/qualysdk/exceptions/Exceptions.py
+++ b/qualysdk/exceptions/Exceptions.py
@@ -12,6 +12,14 @@ class AuthenticationError(Exception):
         self.message = message
         super().__init__(message)
 
+class ProxyError(Exception):
+    """
+    Basic exception class for qualysdk when dealing with proxy setting.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
 
 class InvalidCredentialsError(AuthenticationError):
     """


### PR DESCRIPTION
## What?
I've added the possibility to use the sdk passing via different proxies. I've added a proxy_url parameter as optional input of the auth methods that is then passed in the api calls. I've also added a ProxyException that is triggered if the proxy url is not correctly formatted.
- [proxy_url added in auth classes and api calls.](https://github.com/0x41424142/qualysdk/commit/f625bfef21bd686c2638033da9252cbfbd6d94b1)
- [added proxy to missing request in call_api.](https://github.com/0x41424142/qualysdk/commit/9da3bc42f84987119bbb53987fc0ebad04939dff)
## Why?
These changes allow to use the sdk passing through a proxy.
## Testing?
I've tested both basic auth and token auth, I' ve called also a CloudAgent method list_agents to test the centralized call_api method. The following tests passed successfully.