### PR TITLE
Update to WAS Webapp fields

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1354,20 +1354,20 @@ pyyaml = "*"
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.4"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "sys_platform == \"linux\" or sys_platform == \"darwin\" or sys_platform != \"linux\" and sys_platform != \"darwin\""
 files = [
-    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
-    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+    {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
+    {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qualysdk"
-version = "0.3.5"
+version = "0.3.6"
 description = "SDK for interacting with Qualys APIs, across most modules the platform offers."
 authors = ["0x41424142 <jake@jakelindsay.uk>", "0x4A616B65 <jake.lindsay@thermofisher.com>"]
 maintainers = ["Jake Lindsay <jake@jakelindsay.uk>"]

--- a/qualysdk/sql/was.py
+++ b/qualysdk/sql/was.py
@@ -107,6 +107,12 @@ def upload_was_webapps(
         "swaggerFile": types.String().with_variant(TEXT(charset="utf8"), "mysql", "mariadb"),
         "redundancyLinks": types.String().with_variant(TEXT(charset="utf8"), "mysql", "mariadb"),
         "maxRedundancyLinks": types.Integer(),
+        "malwareScheduling_startDate": types.DateTime(),
+        "malwareScheduling_timeZone": types.String().with_variant(TEXT(charset="utf8"), "mysql", "mariadb"),
+        "malwareScheduling_occurrenceType": types.String().with_variant(
+            TEXT(charset="utf8"), "mysql", "mariadb"
+        ),
+        "malwareScheduling_occurrence": types.String().with_variant(TEXT(charset="utf8"), "mysql", "mariadb"),
     }
 
     # Prepare the dataclass for insertion:
@@ -122,6 +128,7 @@ def upload_was_webapps(
             "lastScan",
             "createdBy",
             "updatedBy",
+            "malwareScheduling",
         ],
         inplace=True,
     )

--- a/qualysdk/was/data_classes/WebApp.py
+++ b/qualysdk/was/data_classes/WebApp.py
@@ -102,6 +102,14 @@ class WebApp(BaseClass):
     swaggerFile: SwaggerFile = None
     redundancyLinks: BaseList = None
     maxRedundancyLinks: Union[str, int] = None
+    malwareScheduling: dict = None
+    # malwareScheduling is parsed into below field:
+    malwareScheduling_startDate: Union[str, datetime] = None
+    malwareScheduling_timeZone: str = None
+    malwareScheduling_occurrenceType: str = None
+    malwareScheduling_occurrence: Union[dict, str] = None
+    # end malwareScheduling
+
 
     def __post_init__(self):
         DT_FIELDS = ["createdDate", "updatedDate"]
@@ -396,6 +404,19 @@ class WebApp(BaseClass):
             if self.swaggerFile:
                 data = self.swaggerFile
                 setattr(self, "swaggerFile", SwaggerFile.from_dict(data))
+
+            if self.malwareScheduling:
+                startDate = self.malwareScheduling.get("startDate")
+                if startDate:
+                    setattr(self, "malwareScheduling_startDate", datetime.fromisoformat(startDate))
+                else:
+                    setattr(self, "malwareScheduling_startDate", None)
+                
+                setattr(self, "malwareScheduling_timeZone", self.malwareScheduling.get("timeZone", dict()).get("code", ""))
+                setattr(self, "malwareScheduling_occurrenceType", self.malwareScheduling.get("occurrenceType", ""))
+                setattr(self, "malwareScheduling_occurrence", str(self.malwareScheduling.get("occurrence", "")))
+                setattr(self, "malwareScheduling", None)
+
 
     def risk_rating(self) -> str:
         """


### PR DESCRIPTION
- **Added malware fields to WAS webapps**
- **updated requests**
- **:art: Format Python code with psf/black**

THIS RELEASE MAKES CHANGES TO THE WAS WEBAPP DATACLASS AND SQL COLUMNS. THE FOLLOWING ATTRIBUTES/COLUMNS ARE ADDED:

- malwareScheduling_startDate (`datetime.datetime`)
- malwareScheduling_timeZone (`str`)
- malwareScheduling_occurrenceType (`str`)
- malwareScheduling_occurrence (`str`, dict-like)
